### PR TITLE
Pin libpng

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
       - tab_space.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
 
 requirements:
@@ -21,14 +21,14 @@ requirements:
     - python
     - ecmwf_grib
     - jasper
-    - libpng >=1.6.21,<1.7
+    - libpng >=1.6.23,<1.7
     - pyproj
 
   run:
     - python
     - ecmwf_grib
     - jasper
-    - libpng >=1.6.21,<1.7
+    - libpng >=1.6.23,<1.7
     - pyproj
     - numpy
 
@@ -47,3 +47,4 @@ extra:
   recipe-maintainers:
     - dopplershift
     - jjhelmus
+    - ocefpaf


### PR DESCRIPTION
`ecmwf_grib` was update twice and the two latest version lack `libgrib_api.so.1`. So this rebuild should also fix #8.