### PR TITLE
fix sha256sum

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,5 +61,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - akrherz
     - dopplershift
     - ocefpaf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/jswhit/pygrib/archive/v{{ version }}rel.tar.gz
-  sha256: 79e9dacbbf4fc15a6bb86194697c25a072883649c2b1e952c16c67b31b57a79c
+  sha256: c2a5cc313469bfc10053926dec797610e2dc79bb6db075529c08be34ef69e90f
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

@conda-forge-admin, please rerender

Present pygrib build (linux 64 at least) has jasper pinned at `jasper >=1.900.1,<2.0a0`, lets see if we can march this forward.