### PR TITLE
Build 2.1.8

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-13
+    vmImage: macOS-15
   strategy:
     matrix:
       osx_64_python3.10.____cpython:

--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - linux-64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -6,10 +6,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
@@ -28,8 +26,5 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - linux-64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - linux-aarch64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - linux-aarch64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - linux-aarch64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - linux-aarch64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -6,10 +6,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
@@ -28,8 +26,5 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - linux-aarch64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -28,8 +26,5 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
+++ b/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
@@ -6,10 +6,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
@@ -28,8 +26,5 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -30,8 +30,5 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -30,8 +30,5 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -30,8 +30,5 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -30,8 +30,5 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.13'
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 jasper:
@@ -30,8 +30,5 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -30,8 +30,5 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - osx-arm64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -30,8 +30,5 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - osx-arm64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -30,8 +30,5 @@ python:
 - 3.12.* *_cpython
 target_platform:
 - osx-arm64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -30,8 +30,5 @@ python:
 - 3.13.* *_cp313
 target_platform:
 - osx-arm64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 jasper:
@@ -30,8 +30,5 @@ python:
 - 3.14.* *_cp314
 target_platform:
 - osx-arm64
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -22,8 +22,5 @@ target_platform:
 - win-64
 vc:
 - '14'
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -22,8 +22,5 @@ target_platform:
 - win-64
 vc:
 - '14'
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -22,8 +22,5 @@ target_platform:
 - win-64
 vc:
 - '14'
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -22,8 +22,5 @@ target_platform:
 - win-64
 vc:
 - '14'
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/.ci_support/win_64_python3.14.____cp314.yaml
+++ b/.ci_support/win_64_python3.14.____cp314.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- conda-forge,conda-forge/label/python_rc
+- conda-forge
 channel_targets:
 - conda-forge main
 jasper:
@@ -22,8 +22,5 @@ target_platform:
 - win-64
 vc:
 - '14'
-zip_keys:
-- - python
-  - channel_sources
 zlib:
 - '1'

--- a/README.md
+++ b/README.md
@@ -324,12 +324,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -356,7 +356,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/pygrib-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.6" %}
+{% set version = "2.1.8" %}
 
 package:
   name: pygrib
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://github.com/jswhit/pygrib/archive/v{{ version }}rel.tar.gz
-  sha256: 4466c9b2c8f4e5a45df1fa3b733697bba8e1cc31aba0f8aae8cfd3890e48aae3
+  sha256: 78bae1cf927e3083149a1b618c034882dc980bf5d3375befd93d38fafb5e3a61
   patches:
     - fix-new-cython.patch
 
 build:
-  number: 2
+  number: 0
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
*  Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I stumbled into the fact that the bot was unhappy about an automated version update

```
57.00 attempts - bot error ([bot CI job](https://github.com/regro/cf-scripts/actions/runs/19279722448)): main:
Traceback (most recent call last):
  File "/opt/autotick-bot/conda_forge_tick/container_cli.py", line 119, in _run_bot_task
    data = func(attrs=attrs, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/autotick-bot/conda_forge_tick/container_cli.py", line 233, in _migrate_feedstock
    data = run_migration_local(
           ^^^^^^^^^^^^^^^^^^^^
  File "/opt/autotick-bot/conda_forge_tick/migration_runner.py", line 270, in run_migration_local
    data["migrate_return_value"] = migrator.migrate(
                                   ^^^^^^^^^^^^^^^^^
  File "/opt/autotick-bot/conda_forge_tick/migrators/version.py", line 310, in migrate
    raise VersionMigrationError(
conda_forge_tick.migrators.version.VersionMigrationError: The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!

Please check the URLs in your recipe with version '2.1.8rel' to make sure they exist!

We also found the following errors:

 - could not hash URL template 'https://github.com/jswhit/pygrib/archive/v{{ version }}rel.tar.gz'
 ```

@conda-forge-admin please rerender